### PR TITLE
Session limit errors

### DIFF
--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -62,7 +62,7 @@ function strategy.save(session, close)
         return default.modify(session, "save", close, key(session))
     else
         ngx.log(ngx.ERROR, "Session limit reach session can not be saved")
-        return nil
+        return nil, "Session limit reached"
     end
 end
 

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -61,7 +61,7 @@ function strategy.save(session, close)
         ngx.log(ngx.DEBUG, "Saving session")
         return default.modify(session, "save", close, key(session))
     else
-        ngx.log(ngx.ERROR, "Session limit reach session can not be saved")
+        ngx.log(ngx.ERR, "Session limit reach session can not be saved")
         return nil, "Session limit reached"
     end
 end

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -62,7 +62,7 @@ function strategy.save(session, close)
         return default.modify(session, "save", close, key(session))
     else
         ngx.log(ngx.ERR, "Session limit reach session can not be saved")
-        ngx.exit(ngx.HTTP_TOO_MANY_REQUESTS)
+        ngx.exit(430)
     end
 end
 

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -62,7 +62,7 @@ function strategy.save(session, close)
         return default.modify(session, "save", close, key(session))
     else
         ngx.log(ngx.ERR, "Session limit reach session can not be saved")
-        return nil, "Session limit reached"
+        ngx.exit(ngx.HTTP_TOO_MANY_REQUESTS)
     end
 end
 


### PR DESCRIPTION
In the event session limit is identified, do not continue with code execution. 

Prevent returning to callers lacking session error handling by forcing nginx to exit with 429 status code (breaking current code execution)