### PR TITLE
Get lua-resty-session v3.10 updates from mainstream

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,8 @@ All notable changes to `lua-resty-session` will be documented in this file.
 ### Fixed
 - Fix #138 issue of chunked cookies are not expired when session shrinks,
   thanks @alexdowad.
+- Fix #134 where regenerate strategy destroyed previous session when calling
+  `session:regenerate`, it should just `ttl` the old session.
 
 ### Added
 - AES GCM mode support was added to AES cipher.

--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,7 @@
 All notable changes to `lua-resty-session` will be documented in this file.
 
 
-## [3.9] - Upcoming
+## [3.9] - 2022-01-12
 ### Changed
 - Optimize Redis and Memcache storage adapters to not connect to database
   when not needed.

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,12 @@
 
 All notable changes to `lua-resty-session` will be documented in this file.
 
+## [3.10] - 2022-01-14
+### Fixed
+- 3.9 introduced an issue where calling session:regenerate with flush=true,
+  didn't really flush if the session strategy was `regenerate`.
+
+
 ## [3.9] - 2022-01-14
 ### Fixed
 - Fix #138 issue of chunked cookies are not expired when session shrinks,

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,13 @@
 
 All notable changes to `lua-resty-session` will be documented in this file.
 
+## Unreleased
+### Added
+- Redis ACL authentication is now available.
+  - Add `session_redis_username`
+  - Add `session_redis_password`
+  - Deprecate `session_redis_auth`; use `session_redis_password`
+
 ## [3.8] - 2021-01-04
 ### Added
 - Connection options are now passed to `redis cluster client` as well.
@@ -10,10 +17,10 @@ All notable changes to `lua-resty-session` will be documented in this file.
 ## [3.7] - 2020-10-27
 ### Fixed
 - Fix #107 where `session.start` could release a lock for a short period
-  
+
 ### Added
 - Add `keep_lock` argument to `session.open`
-- Add pluggable compressors, and implement `none` and `zlib` compressor   
+- Add pluggable compressors, and implement `none` and `zlib` compressor
 
 
 ## [3.6] - 2020-06-24
@@ -27,13 +34,13 @@ All notable changes to `lua-resty-session` will be documented in this file.
 - Fix `session:hide()` to not clear non-session request cookies that it
   seemed to do in some cases as reported by @altexy who also provided
   initial fix with #100. Thank you!
-   
+
 
 ## [3.4] - 2020-05-08
 ### Fixed
 - Fix session_cookie_maxsize - error attempt to compare string with number,
   fixes #98, thank you @vavra5
-  
+
 ### Changed
 - More robust and uniform configuration parsing
 
@@ -86,12 +93,12 @@ All notable changes to `lua-resty-session` will be documented in this file.
 
 ### Changed
 - The whole codebase was refactored and simplified, especially implementing
-  new storage adapters is now a lot easier 
+  new storage adapters is now a lot easier
 - Redis and Memcached `spinlockwait` was changed from microseconds to milliseconds and default
   is set to `150` milliseconds,
 - Redis and Memcache will only release locks that current session instance holds
 - DSHM `session_dshm_store` was renamed to `session_dshm_region`
-- BASE64 encoding now strips the padding 
+- BASE64 encoding now strips the padding
 
 
 ## [2.26] - 2020-02-11
@@ -330,7 +337,7 @@ All notable changes to `lua-resty-session` will be documented in this file.
   the cookie (until start is called).
   See also: https://github.com/bungle/lua-resty-session/issues/12
   Thanks @junhanamaki
-  
+
 ### Fixed
 - Fixed cookie expiration time format on Firefox bug:
   https://github.com/bungle/lua-resty-session/pull/10

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,11 @@
 
 All notable changes to `lua-resty-session` will be documented in this file.
 
+## [3.8] - 2021-01-04
+### Added
+- Connection options are now passed to `redis cluster client` as well.
+
+
 ## [3.7] - 2020-10-27
 ### Fixed
 - Fix #107 where `session.start` could release a lock for a short period

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,10 @@
 All notable changes to `lua-resty-session` will be documented in this file.
 
 ## Unreleased
+### Fixed
+- Fix #138 issue of chunked cookies are not expired when session shrinks,
+  thanks @alexdowad.
+
 ### Added
 - AES GCM mode support was added to AES cipher.
   This is recommended, but for backward compatibility it was not set as default.

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,9 @@ All notable changes to `lua-resty-session` will be documented in this file.
 
 ## Unreleased
 ### Added
+- AES GCM mode support was added to AES cipher.
+  This is recommended, but for backward compatibility it was not set as default.
+  It will be changed in 4.0 release.
 - Redis ACL authentication is now available.
   - Add `session_redis_username`
   - Add `session_redis_password`

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,13 @@
 
 All notable changes to `lua-resty-session` will be documented in this file.
 
+
+## [3.9] - Upcoming
+### Changed
+- Optimize Redis and Memcache storage adapters to not connect to database
+  when not needed.
+
+
 ## [3.8] - 2021-01-04
 ### Added
 - Connection options are now passed to `redis cluster client` as well.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 – 2021, Aapo Talvensaari
+Copyright (c) 2014 – 2022, Aapo Talvensaari
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 – 2020, Aapo Talvensaari
+Copyright (c) 2014 – 2021, Aapo Talvensaari
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ http {
         listen       8080;
         server_name  localhost;
         default_type text/html;
-        
+
         location / {
             content_by_lua '
                 ngx.say("<html><body><a href=/start>Start the test</a>!</body></html>")
@@ -109,7 +109,7 @@ unencrypted data, `http_user_agent` and `scheme`. You may also configure it to u
 setting `set $session_check_addr on;` (but this may be problematic with clients behind proxies or NATs that
 change the remote address between requests). If you are using SSL Session IDs you may also add
 `set $session_check_ssi on;`, but please check that it works accordingly (you may need to adjust both SSL
-and session library settings). 
+and session library settings).
 
 The data part is encrypted with AES-algorithm (by default it uses OpenSSL `EVP_aes_256_cbc` and
 `EVP_sha512` functions that are provided with `lua-resty-string`. They come pre-installed with
@@ -132,7 +132,7 @@ JSON encoding is done by the bundled OpenResty cJSON library (Lua cJSON). We do 
 serializers as well, though only serializer currently supplied is JSON. Cookie's path scope is by
 default `/` (meaning that it will be send to all paths in the server). The domain scope is not set
 by default, and it means that the cookie will only be sent back to same domain/host where it originated.
-If you set  session name (e.g. `set $session_name <value>`) and it contains prefix `__Secure-` the 
+If you set  session name (e.g. `set $session_name <value>`) and it contains prefix `__Secure-` the
 `Secure` flag will be forced, and if it contains `__Host-` the `path` is forced to `/` and the
 `domain` is removed, and the `Secure` flag will be forced too.
 
@@ -345,7 +345,7 @@ The keys stored in shared dictionary are in form:
 #### Memcache Storage Adapter
 
 Memcache storage adapter stores the session data inside Memcached server.
-It is scalable and works with web farms. 
+It is scalable and works with web farms.
 
 Memcache adapter can be selected with configuration:
 
@@ -368,7 +368,7 @@ set $session_memcache_spinlockwait     150;  # (in milliseconds)
 set $session_memcache_maxlockwait      30;   # (in seconds)
 set $session_memcache_pool_name        sessions;
 set $session_memcache_pool_timeout     1000; # (in milliseconds)
-set $session_memcache_pool_size        10;                 
+set $session_memcache_pool_size        10;
 set $session_memcache_pool_backlog     10;
 ```
 
@@ -379,7 +379,7 @@ The keys stored in Memcached are in form:
 #### Redis Storage Adapter
 
 Redis storage adapter stores the session data inside Redis server.
-It is scalable and works with web farms. 
+It is scalable and works with web farms.
 
 Redis adapter can be selected with configuration:
 
@@ -400,20 +400,23 @@ set $session_redis_host                     127.0.0.1;
 set $session_redis_port                     6379;
 set $session_redis_ssl                      off;
 set $session_redis_ssl_verify               off;
-set $session_redis_server_name              example.com; # for TLS SNI 
-set $session_redis_auth                     password;
+set $session_redis_server_name              example.com; # for TLS SNI
+set $session_redis_username                 username;
+set $session_redis_password                 password;
 set $session_redis_uselocking               on;
 set $session_redis_spinlockwait             150;  # (in milliseconds)
 set $session_redis_maxlockwait              30;   # (in seconds)
 set $session_redis_pool_name                sessions;
 set $session_redis_pool_timeout             1000; # (in milliseconds)
-set $session_redis_pool_size                10;                 
+set $session_redis_pool_size                10;
 set $session_redis_pool_backlog             10;
 set $session_redis_cluster_name             redis-cluster;
 set $session_redis_cluster_dict             sessions;
 set $session_redis_cluster_maxredirections  5;
 set $session_redis_cluster_nodes            '127.0.0.1:30001 127.0.0.1:30002 127.0.0.1:30003 127.0.0.1:30004 127.0.0.1:30005 127.0.0.1:30006';
 ```
+
+**Note**: `session_redis_auth` has been deprecated; use `session_redis_password`.
 
 To use `cluster` you need also to install:
 ```shell
@@ -431,11 +434,11 @@ The keys stored in Redis are in form:
 #### DSHM Storage Adapter
 
 DSHM storage adapter stores the session data inside Distributed Shared Memory server based
-on Vertx and Hazelcast. It is scalable and works with web farms. 
+on Vertx and Hazelcast. It is scalable and works with web farms.
 
 The DSHM lua library and the DSHM servers should be installed conforming with the documentation
-[here](https://github.com/grrolland/ngx-distributed-shm/blob/master/README.md).  
-  
+[here](https://github.com/grrolland/ngx-distributed-shm/blob/master/README.md).
+
 
 DSHM adapter can be selected with configuration:
 
@@ -454,7 +457,7 @@ set $session_dshm_host             127.0.0.1;
 set $session_dshm_port             4321;
 set $session_dshm_pool_name        sessions;
 set $session_dshm_pool_timeout     1000; # (in milliseconds)
-set $session_dshm_pool_size        10;                 
+set $session_dshm_pool_size        10;
 set $session_dshm_pool_backlog     10;
 ```
 
@@ -775,7 +778,7 @@ if session.present then
 end
 -- Now let's really start the session
 -- (session.started will be always false in this example):
-if not session.started then 
+if not session.started then
     session:start() -- with some storage adapters this will held a lock.
 end
 
@@ -1068,7 +1071,7 @@ as where the original cookie was delivered. This check is disabled by default.
 
 #### boolean session.check.scheme
 
-`session.check.scheme` is additional check to validate that the request was made using the same protocol 
+`session.check.scheme` is additional check to validate that the request was made using the same protocol
 as the one used when the original cookie was delivered. This check is enabled by default.
 
 ## Nginx Configuration Variables

--- a/README.md
+++ b/README.md
@@ -1174,7 +1174,7 @@ The changes of every release of this module is recorded in [Changes.md](https://
 `lua-resty-session` uses two clause BSD license.
 
 ```
-Copyright (c) 2014 – 2021 Aapo Talvensaari
+Copyright (c) 2014 – 2022 Aapo Talvensaari
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -1175,7 +1175,7 @@ The changes of every release of this module is recorded in [Changes.md](https://
 `lua-resty-session` uses two clause BSD license.
 
 ```
-Copyright (c) 2014 – 2021 Aapo Talvensaari
+Copyright (c) 2014 – 2022 Aapo Talvensaari
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -1171,7 +1171,7 @@ The changes of every release of this module is recorded in [Changes.md](https://
 `lua-resty-session` uses two clause BSD license.
 
 ```
-Copyright (c) 2014 – 2020 Aapo Talvensaari
+Copyright (c) 2014 – 2021 Aapo Talvensaari
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -544,9 +544,9 @@ By default this will use `256` bits key size. This can be configured with Nginx
 **mode**
 
 `session.aes.mode` holds the mode of the cipher. `lua-resty-string` supports AES in `ecb`, `cbc`,
-`cfb1`, `cfb8`, `cfb128`, `ofb`, and `ctr` modes (ctr mode is not available with 256 bit keys).
-See `aes.cipher` function in `lua-resty-string` for more information. By default `cbc` mode is
-used. This can be configured with Nginx `set $session_aes_mode cbc;`.
+`cfb1`, `cfb8`, `cfb128`, `ofb`, `ctr`, and `gcm` (recommended!) modes (ctr mode is not available
+with 256 bit keys).  See `aes.cipher` function in `lua-resty-string` for more information.
+By default `cbc` mode is  used. This can be configured with Nginx `set $session_aes_mode cbc;`.
 
 **hash**
 
@@ -580,10 +580,11 @@ There isn't any settings for None adapter as it is basically a no-op adapter.
 If you want to write your own cipher adapter, you need to implement these three methods:
 
 * `cipher new(session)`
-* `string cipher:encrypt(data, key, iv or salt, associated data)`
-* `string cipher:decrypt(ciphertext, key, iv or salt, associated data)`
+* `string, err, tag = cipher:encrypt(data, key, salt, aad)`
+* `string, err, tag = cipher:decrypt(data, key, salt, aad, tag)`
 
-If you do not use say iv or associated data in your cipher, you can ignore them.
+If you do not use say salt or aad (associated data) in your cipher, you can ignore them.
+If you don't use `AEAD` construct (like `AES in GCM-mode`), don't return `tag`.
 
 You have to place your adapter inside `resty.session.ciphers` for auto-loader to work.
 

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -478,7 +478,7 @@ function session:parse_cookie(value)
 end
 
 function session.new(opts)
-    if getmetatable(opts) == session then
+    if opts and getmetatable(opts) == session then
         return opts
     end
 
@@ -573,7 +573,7 @@ end
 
 function session.open(opts, keep_lock)
     local self = opts
-    if getmetatable(self) == session then
+    if self and getmetatable(self) == session then
         if self.opened then
             return self, self.present
         end
@@ -614,7 +614,7 @@ function session.open(opts, keep_lock)
 end
 
 function session.start(opts)
-    if getmetatable(opts) == session and opts.started then
+    if opts and getmetatable(opts) == session and opts.started then
         return opts, opts.present
     end
 
@@ -657,7 +657,7 @@ function session.start(opts)
 end
 
 function session.destroy(opts)
-    if getmetatable(opts) == session and opts.destroyed then
+    if opts and getmetatable(opts) == session and opts.destroyed then
         return true
     end
 

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -684,7 +684,9 @@ end
 
 function session:regenerate(flush, close)
     close = close ~= false
-    regenerate(self, flush)
+    if not self.strategy.regenerate then
+        regenerate(self, flush)
+    end
     return save(self, close)
 end
 

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -684,9 +684,18 @@ end
 
 function session:regenerate(flush, close)
     close = close ~= false
-    if not self.strategy.regenerate then
+    if self.strategy.regenerate then
+        if flush then
+            self.data = {}
+        end
+
+        if not self.id then
+            self.id = session:identifier()
+        end
+    else
         regenerate(self, flush)
     end
+
     return save(self, close)
 end
 

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -24,6 +24,7 @@ local getmetatable = getmetatable
 local bytes        = random.bytes
 
 local UNDERSCORE = byte("_")
+local EXPIRE_FLAGS = "; Expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0"
 
 local COOKIE_PARTS = {
     DEFAULT = {
@@ -135,57 +136,57 @@ local function set_cookie(session, value, expires)
      -- build cookie parameters, elements 1+2 will be set later
     if expires then
         -- we're expiring/deleting the data, so set an expiry in the past
-        output[i] = "; Expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0"
-        i = i + 1
+        output[i] = EXPIRE_FLAGS
     elseif cookie.persistent then
-        output[i]   = "; Expires="
-        output[i+1] = http_time(session.expires)
-        output[i+2] = "; Max-Age="
-        output[i+3] = cookie.lifetime
-        i = i + 4
+        -- persistent cookies have an expiry
+        output[i]   = "; Expires="  .. http_time(session.expires) .. "; Max-Age=" .. cookie.lifetime
+    else
+        -- just to reserve index 3 for expiry as cookie might get smaller,
+        -- and some cookies need to be expired.
+        output[i] = ""
     end
 
     if cookie.domain and cookie.domain ~= "localhost" and cookie.domain ~= "" then
-        output[i]   = "; Domain="
-        output[i+1] = cookie.domain
-        i = i + 2
+        i = i + 1
+        output[i]   = "; Domain=" .. cookie.domain
     end
 
-    output[i]   = "; Path="
-    output[i+1] = cookie.path or "/"
-    i = i + 2
+    i = i + 1
+    output[i] = "; Path=" .. (cookie.path or "/")
 
     if cookie.samesite == "Lax"
     or cookie.samesite == "Strict"
     or cookie.samesite == "None"
     then
-        output[i] = "; SameSite="
-        output[i+1] = cookie.samesite
-        i = i + 2
+        i = i + 1
+        output[i] = "; SameSite=" .. cookie.samesite
     end
 
     if cookie.secure then
-        output[i] = "; Secure"
         i = i + 1
+        output[i] = "; Secure"
     end
 
     if cookie.httponly then
+        i = i + 1
         output[i] = "; HttpOnly"
     end
 
     -- How many chunks do we need?
     local cookie_parts
+    local cookie_chunks
     if expires then
         -- expiring cookie, so deleting data. Do not measure data, but use
         -- existing chunk count to make sure we clear all of them
         cookie_parts = cookie.chunks or 1
     else
         -- calculate required chunks from data
-        cookie_parts = max(ceil(#value / cookie.maxsize), 1)
+        cookie_chunks = max(ceil(#value / cookie.maxsize), 1)
+        cookie_parts = max(cookie_chunks, cookie.chunks or 1)
     end
 
     local cookie_header = header["Set-Cookie"]
-    for j=1, cookie_parts do
+    for j = 1, cookie_parts do
         -- create numbered chunk names if required
         local chunk_name = { session.name }
         if j > 1 then
@@ -201,10 +202,15 @@ local function set_cookie(session, value, expires)
         if expires then
             -- expiring cookie, so deleting data; clear it
             output[2] = ""
+        elseif j > cookie_chunks then
+            -- less chunks than before, clearing excess cookies
+            output[2] = ""
+            output[3] = EXPIRE_FLAGS
+
         else
             -- grab the piece for the current chunk
             local sp = j * cookie.maxsize - (cookie.maxsize - 1)
-            if j < cookie_parts then
+            if j < cookie_chunks then
                 output[2] = sub(value, sp, sp + (cookie.maxsize - 1)) .. "0"
             else
                 output[2] = sub(value, sp)
@@ -226,7 +232,7 @@ local function set_cookie(session, value, expires)
                 end
             end
             if not found then
-                cookie_header[cookie_count +1] = cookie_content
+                cookie_header[cookie_count + 1] = cookie_content
             end
         elseif header_type == "string" and find(cookie_header, chunk_name, 1, true) ~= 1  then
             cookie_header = { cookie_header, cookie_content }

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -374,7 +374,7 @@ local function init()
 end
 
 local session = {
-    _VERSION = "3.7"
+    _VERSION = "3.8"
 }
 
 session.__index = session

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -374,7 +374,7 @@ local function init()
 end
 
 local session = {
-    _VERSION = "3.8"
+    _VERSION = "3.9"
 }
 
 session.__index = session

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -380,7 +380,7 @@ local function init()
 end
 
 local session = {
-    _VERSION = "3.9"
+    _VERSION = "3.10"
 }
 
 session.__index = session

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -646,7 +646,6 @@ function session.start(opts)
             return nil, err or "unable to touch session cookie"
         end
     end
-    ngx.log(ngx.INFO, "session: " .. self.id .. " created")
     return self, true
 end
 

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -304,6 +304,7 @@ end
 local function touch(session, close)
     if set_usebefore(session) then
         -- usebefore was updated, so set cookie
+        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed")
         local cookie, err = session.strategy.touch(session, close)
         if not cookie then
             return nil, err or "unable to touch session cookie"

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -304,7 +304,6 @@ end
 local function touch(session, close)
     if set_usebefore(session) then
         -- usebefore was updated, so set cookie
-        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed")
         local cookie, err = session.strategy.touch(session, close)
         if not cookie then
             return nil, err or "unable to touch session cookie"

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -678,7 +678,7 @@ end
 function session:regenerate(flush, close)
     close = close ~= false
     regenerate(self, flush)
-    ngx.log(ngx.INFO, "session: " .. self.id .. " renewed")
+    ngx.log(ngx.WARN, "session: " .. self.encoder.encode(self.id) .. " renewed")
 
     return save(self, close)
 end

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -646,7 +646,7 @@ function session.start(opts)
             return nil, err or "unable to touch session cookie"
         end
     end
-
+    ngx.log(ngx.INFO, "session: " .. self.id .. " created")
     return self, true
 end
 
@@ -672,6 +672,7 @@ function session.destroy(opts)
     self.started   = nil
     self.closed    = true
     self.destroyed = true
+    ngx.log(ngx.INFO, "session: " .. self.id .. " ended")
 
     return set_cookie(self, "", true)
 end
@@ -679,6 +680,8 @@ end
 function session:regenerate(flush, close)
     close = close ~= false
     regenerate(self, flush)
+    ngx.log(ngx.INFO, "session: " .. self.id .. " renewed")
+
     return save(self, close)
 end
 

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -671,7 +671,6 @@ function session.destroy(opts)
     self.started   = nil
     self.closed    = true
     self.destroyed = true
-    ngx.log(ngx.INFO, "session: " .. self.id .. " ended")
 
     return set_cookie(self, "", true)
 end

--- a/lib/resty/session/ciphers/none.lua
+++ b/lib/resty/session/ciphers/none.lua
@@ -4,11 +4,11 @@ function cipher.new()
     return cipher
 end
 
-function cipher.encrypt(_, data)
+function cipher.encrypt(_, data, _, _)
     return data
 end
 
-function cipher.decrypt(_, data)
+function cipher.decrypt(_, data, _, _, _)
     return data
 end
 

--- a/lib/resty/session/identifiers/uid.lua
+++ b/lib/resty/session/identifiers/uid.lua
@@ -1,0 +1,41 @@
+local tonumber = tonumber
+local random   = require "resty.random".bytes
+local var      = ngx.var
+
+local defaults = {
+    length = 6,
+    header_name = var.session_header_uid
+}
+
+return function(session)
+    -- local config = session or defaults
+    -- local length = tonumber(config.length, 10) or defaults.length
+    local length = defaults.length
+    -- local uid = ngx.req.get_headers()[defaults.header_name] or ''
+    local uid = ''
+    if session.data and session.data.user then
+        uid = session.data.user.email
+    end
+    local pad = random(length, true) or random(length)
+    ngx.log(ngx.STDERR, "header_name: " .. defaults.header_name .. " uid: " .. uid .. " pad: " .. pad)
+    ngx.log(ngx.STDERR, "session info: ")
+    if session.data.user then
+        for k,v in pairs(session.data.user) do
+            if type(v) == "string" then
+                ngx.log(ngx.STDERR, 'key: ' .. k .. ' value: ' .. v)
+            else
+                ngx.log(ngx.STDERR, 'key: ' .. k)
+            end
+        end
+    end
+    -- for k, v in pairs(session.data) do
+    --    ngx.log(ngx.STDERR, 'session data: ' .. k)
+    --    ngx.log(ngx.STDERR, 'value type: ' .. type(v))
+    --    if type(v) == "string" then
+    --        ngx.log(ngx.STDERR, 'session data value: ' .. v)
+    --    end
+    --end
+
+    -- return uid if avalible with padding
+    return (uid .. pad)
+end

--- a/lib/resty/session/identifiers/uid.lua
+++ b/lib/resty/session/identifiers/uid.lua
@@ -11,14 +11,13 @@ return function(session)
     if session.data and session.data.user then
         uid = session.data.user.email
         local id_encoded = session.encoder.encode(uid .. pad)
+        ngx.log(ngx.DEBUG, "new session: " .. id_encoded .. " old session: " .. session.encoder.encode(session.id))
         ngx.log(
-                ngx.WARN, "session id: " .. id_encoded .. " created for: " .. uid ..
-                        " from session " .. session.encoder.encode(session.id)
-        )
+                ngx.WARN, "authenticated session created for " .. uid)
     else
-        ngx.log(ngx.WARN, "anonymous session id: " .. session.encoder.encode(pad) .. " create for non authenticated user")
+        ngx.log(ngx.DEBUG, "non authenticated session id: " .. session.encoder.encode(pad))
+        ngx.log(ngx.WARN, "session create for non authenticated user")
     end
-    ngx.log(ngx.DEBUG, "uid: " .. uid .. " pad: " .. pad)
 
     -- return uid if avalible with padding
     return (uid .. pad)

--- a/lib/resty/session/identifiers/uid.lua
+++ b/lib/resty/session/identifiers/uid.lua
@@ -1,10 +1,7 @@
-local tonumber = tonumber
 local random   = require "resty.random".bytes
-local var      = ngx.var
 
 local defaults = {
-    length = 6,
-    header_name = var.session_header_uid
+    length = 6
 }
 
 return function(session)

--- a/lib/resty/session/identifiers/uid.lua
+++ b/lib/resty/session/identifiers/uid.lua
@@ -17,24 +17,8 @@ return function(session)
         uid = session.data.user.email
     end
     local pad = random(length, true) or random(length)
-    ngx.log(ngx.STDERR, "header_name: " .. defaults.header_name .. " uid: " .. uid .. " pad: " .. pad)
-    ngx.log(ngx.STDERR, "session info: ")
-    if session.data.user then
-        for k,v in pairs(session.data.user) do
-            if type(v) == "string" then
-                ngx.log(ngx.STDERR, 'key: ' .. k .. ' value: ' .. v)
-            else
-                ngx.log(ngx.STDERR, 'key: ' .. k)
-            end
-        end
-    end
-    -- for k, v in pairs(session.data) do
-    --    ngx.log(ngx.STDERR, 'session data: ' .. k)
-    --    ngx.log(ngx.STDERR, 'value type: ' .. type(v))
-    --    if type(v) == "string" then
-    --        ngx.log(ngx.STDERR, 'session data value: ' .. v)
-    --    end
-    --end
+    ngx.log(ngx.STDERR, "uid: " .. uid .. " pad: " .. pad)
+
 
     -- return uid if avalible with padding
     return (uid .. pad)

--- a/lib/resty/session/identifiers/uid.lua
+++ b/lib/resty/session/identifiers/uid.lua
@@ -1,19 +1,23 @@
 local random   = require "resty.random".bytes
 
 local defaults = {
-    length = 6
+    length = 10
 }
 
 return function(session)
-    -- local config = session or defaults
-    -- local length = tonumber(config.length, 10) or defaults.length
     local length = defaults.length
-    -- local uid = ngx.req.get_headers()[defaults.header_name] or ''
     local uid = ''
+    local pad = random(length, true) or random(length)
     if session.data and session.data.user then
         uid = session.data.user.email
+        local id_encoded = session.encoder.encode(uid .. pad)
+        ngx.log(
+                ngx.WARN, "session id: " .. id_encoded .. " created for: " .. uid ..
+                        " from session " .. session.encoder.encode(session.id)
+        )
+    else
+        ngx.log(ngx.WARN, "anonymous session id: " .. session.encoder.encode(pad) .. " create for non authenticated user")
     end
-    local pad = random(length, true) or random(length)
     ngx.log(ngx.DEBUG, "uid: " .. uid .. " pad: " .. pad)
 
     -- return uid if avalible with padding

--- a/lib/resty/session/identifiers/uid.lua
+++ b/lib/resty/session/identifiers/uid.lua
@@ -14,8 +14,7 @@ return function(session)
         uid = session.data.user.email
     end
     local pad = random(length, true) or random(length)
-    ngx.log(ngx.STDERR, "uid: " .. uid .. " pad: " .. pad)
-
+    ngx.log(ngx.DEBUG, "uid: " .. uid .. " pad: " .. pad)
 
     -- return uid if avalible with padding
     return (uid .. pad)

--- a/lib/resty/session/storage/memcache.lua
+++ b/lib/resty/session/storage/memcache.lua
@@ -206,6 +206,10 @@ function storage:open(id, keep_lock)
 end
 
 function storage:start(id)
+    if not self.uselocking or not self.locked then
+        return true
+    end
+
     local ok, err = self:connect()
     if not ok then
         return nil, err
@@ -244,6 +248,10 @@ function storage:save(id, ttl, data, close)
 end
 
 function storage:close(id)
+    if not self.uselocking or not self.locked then
+        return true
+    end
+
     local ok, err = self:connect()
     if not ok then
         return nil, err

--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -175,6 +175,15 @@ function storage.new(session)
         cluster_nodes = parse_cluster_nodes(cluster.nodes or defaults.cluster.nodes)
     end
 
+    local connect_opts = {
+        pool             = pool.name                         or defaults.pool.name,
+        pool_size        = tonumber(pool.size,           10) or defaults.pool.size,
+        backlog          = tonumber(pool.backlog,        10) or defaults.pool.backlog,
+        server_name      = config.server_name                or defaults.server_name,
+        ssl              = ifnil(config.ssl,                    defaults.ssl),
+        ssl_verify       = ifnil(config.ssl_verify,             defaults.ssl_verify),
+    }
+
     if cluster_nodes then
         self.redis = redis_cluster:new({
             name               = cluster.name                          or defaults.cluster.name,
@@ -186,6 +195,7 @@ function storage.new(session)
             keepalive_cons     = tonumber(pool.size,               10) or defaults.pool.size,
             max_redirection    = tonumber(cluster.maxredirections, 10) or defaults.cluster.maxredirections,
             serv_list          = cluster_nodes,
+            connect_opts       = connect_opts,
         })
         self.cluster = true
 
@@ -212,14 +222,7 @@ function storage.new(session)
         self.auth            = auth
         self.database        = tonumber(config.database,     10) or defaults.database
         self.pool_timeout    = tonumber(pool.timeout,        10) or defaults.pool.timeout
-        self.connect_opts    = {
-            pool             = pool.name                         or defaults.pool.name,
-            pool_size        = tonumber(pool.size,           10) or defaults.pool.size,
-            backlog          = tonumber(pool.backlog,        10) or defaults.pool.backlog,
-            server_name      = config.server_name                or defaults.server_name,
-            ssl              = ifnil(config.ssl,                    defaults.ssl),
-            ssl_verify       = ifnil(config.ssl_verify,             defaults.ssl_verify),
-        }
+        self.connect_opts    = connect_opts
 
         local socket = config.socket or defaults.socket
         if socket and socket ~= "" then

--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -371,6 +371,10 @@ function storage:open(id, keep_lock)
 end
 
 function storage:start(id)
+    if not self.uselocking or not self.locked then
+        return true
+    end
+
     local ok, err = self:connect()
     if not ok then
         return nil, err
@@ -407,6 +411,10 @@ function storage:save(id, ttl, data, close)
 end
 
 function storage:close(id)
+    if not self.uselocking or not self.locked then
+        return true
+    end
+
     local ok, err = self:connect()
     if not ok then
         return nil, err

--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -330,6 +330,27 @@ function storage:get(key)
     return data
 end
 
+function storage:scan(pattern)
+    -- redis SCAN call
+    -- in: pattern (str)
+    -- TODO: add count and cursor
+    -- output: table
+    local ok, err = self:connect()
+    if ok then
+        ngx.log(ngx.DEBUG, "scan pattern: " .. pattern)
+        local data, err = self.redis:scan(0, "MATCH", defaults.prefix .. ":" .. pattern, "COUNT", 100)
+        if err then
+            ngx.log(ngx.ERR, "Data: " .. type(data) .. ' err: ' .. err)
+            return nil, err
+        elseif data then
+            ngx.log(ngx.DEBUG, "Number of sessions found: " .. #data[2])
+            return data
+        end
+    end
+    ngx.log(ngx.ERR, "Redis Connection Error: " .. err)
+    return nil, err
+end
+
 function storage:set(key, data, lifetime)
     return self.redis:setex(key, lifetime, data)
 end

--- a/lib/resty/session/strategies/default.lua
+++ b/lib/resty/session/strategies/default.lua
@@ -8,9 +8,9 @@ function strategy.load(session, cookie, key, keep_lock)
   local id         = cookie.id
   local id_encoded = session.encoder.encode(id)
 
-  local data, err
+  local data, err, tag
   if storage.open then
-    data, err = session.storage:open(id_encoded, keep_lock)
+    data, err = storage:open(id_encoded, keep_lock)
     if not data then
       return nil, err or "cookie data was not found"
     end
@@ -29,27 +29,50 @@ function strategy.load(session, cookie, key, keep_lock)
 
   local hkey = session.hmac(session.secret, key)
 
-  data, err = session.cipher:decrypt(data, hkey, id, session.key)
+  data, err, tag = session.cipher:decrypt(data, hkey, id, session.key, hash)
   if not data then
-    session.storage:close(id_encoded)
+    if storage.close then
+      storage:close(id_encoded)
+    end
+
     return nil, err or "unable to decrypt data"
   end
 
-  local input = concat{ key, data, session.key }
-  if session.hmac(hkey, input) ~= hash then
-    session.storage:close(id_encoded)
-    return nil, "cookie has invalid signature"
+  if tag then
+    if tag ~= hash then
+      if storage.close then
+        storage:close(id_encoded)
+      end
+
+      return nil, "cookie has invalid tag"
+    end
+
+  else
+    local input = concat{ key, data, session.key }
+    if session.hmac(hkey, input) ~= hash then
+      if storage.close then
+        storage:close(id_encoded)
+      end
+
+      return nil, "cookie has invalid signature"
+    end
   end
 
   data, err = session.compressor:decompress(data)
   if not data then
-    session.storage:close(id_encoded)
+    if storage.close then
+      storage:close(id_encoded)
+    end
+
     return nil, err or "unable to decompress data"
   end
 
   data, err = session.serializer.deserialize(data)
   if not data then
-    session.storage:close(id_encoded)
+    if storage.close then
+      storage:close(id_encoded)
+    end
+
     return nil, err or "unable to deserialize data"
   end
 
@@ -102,7 +125,6 @@ function strategy.modify(session, action, close, key)
     key = concat{ id, expires, usebefore }
   end
 
-  local hkey = session.hmac(session.secret, key)
   local data, err = session.serializer.serialize(session.data)
   if not data then
     if close and storage.close then
@@ -121,10 +143,11 @@ function strategy.modify(session, action, close, key)
     return nil, err or "unable to compress data"
   end
 
-  local hash = session.hmac(hkey, concat{ key, data, session.key })
+  local hkey = session.hmac(session.secret, key)
 
-  data, err = session.cipher:encrypt(data, hkey, id, session.key)
-  if not data then
+  local encrypted_data, tag
+  encrypted_data, err, tag = session.cipher:encrypt(data, hkey, id, session.key)
+  if not encrypted_data then
     if close and storage.close then
       storage:close(id_encoded)
     end
@@ -132,9 +155,18 @@ function strategy.modify(session, action, close, key)
     return nil, err
   end
 
+  local hash
+  if tag then
+    hash = tag
+  else
+    -- it would be better to calculate signature from encrypted_data,
+    -- but this is kept for backward compatibility
+    hash = session.hmac(hkey, concat{ key, data, session.key })
+  end
+
   if action == "save" and storage.save then
     local ok
-    ok, err = storage:save(id_encoded, ttl, data, close)
+    ok, err = storage:save(id_encoded, ttl, encrypted_data, close)
     if not ok then
       return nil, err
     end
@@ -156,8 +188,8 @@ function strategy.modify(session, action, close, key)
   if storage.save then
     cookie = concat({ id_encoded, expires, hash }, "|")
   else
-    data = session.encoder.encode(data)
-    cookie = concat({ id_encoded, expires, data, hash }, "|")
+    local encoded_data = session.encoder.encode(encrypted_data)
+    cookie = concat({ id_encoded, expires, encoded_data, hash }, "|")
   end
 
   return cookie
@@ -187,9 +219,11 @@ end
 
 function strategy.close(session)
   local id = session.id
-  local storage = session.storage
-  if id and storage.close then
-    return storage:close(session.encoder.encode(id))
+  if id then
+    local storage = session.storage
+    if storage.close then
+      return storage:close(session.encoder.encode(id))
+    end
   end
 
   return true

--- a/lib/resty/session/strategies/default.lua
+++ b/lib/resty/session/strategies/default.lua
@@ -11,6 +11,8 @@ function strategy.load(session, cookie, key, keep_lock)
   if storage.open then
     data, err = session.storage:open(session.encoder.encode(id), keep_lock)
     if not data then
+      ngx.log(ngx.DEBUG, "session: " .. session.encoder.encode(id))
+      ngx.log(ngx.ERR, "session not found. Possible timeout.")
       return nil, err or "cookie data was not found"
     end
 

--- a/lib/resty/session/strategies/regenerate.lua
+++ b/lib/resty/session/strategies/regenerate.lua
@@ -25,8 +25,8 @@ function strategy.touch(session, close)
 end
 
 function strategy.save(session, close)
-  local storage = session.storage
   if session.present then
+    local storage = session.storage
     if storage.ttl then
       storage:ttl(session.encoder.encode(session.id), session.cookie.discard, true)
     elseif storage.close then

--- a/lib/resty/session/strategies/regenerate.lua
+++ b/lib/resty/session/strategies/regenerate.lua
@@ -3,9 +3,10 @@ local default = require "resty.session.strategies.default"
 local concat  = table.concat
 
 local strategy = {
-  start   = default.start,
-  destroy = default.destroy,
-  close   = default.close,
+  regenerate = true,
+  start      = default.start,
+  destroy    = default.destroy,
+  close      = default.close,
 }
 
 local function key(source)

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -86,7 +86,11 @@ function strategy.destroy(session)
 end
 
 function strategy.touch(session, close)
-    ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed for user: " .. session.data.user.email)
+    if session.data and session.data.user then
+        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed for user: " .. session.data.user.email)
+    else
+        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed")
+    end
 
     return default.modify(session, "save", close, key(session))
 end

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -12,7 +12,6 @@ local strategy = {
   start   = regenerate.start,
   close   = regenerate.close,
   open    = regenerate.open,
-  touch   = regenerate.touch
 }
 
 local function key(source)
@@ -84,6 +83,12 @@ function strategy.destroy(session)
     end
   end
   return true
+end
+
+function strategy.touch(session, close)
+    ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed")
+
+    return default.modify(session, "save", close, key(session))
 end
 
 return strategy

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -71,10 +71,11 @@ function strategy.destroy(session)
   if id then
     local storage = session.storage
     if storage.destroy then
-      if session.data and session.data.user then
-        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(id) .. " ended for user: " .. session.data.user.email)
-      else
-        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(id) .. " ended")
+        ngx.log(ngx.DEBUG, "session: " .. session.encoder.encode(id))
+        if session.data and session.data.user then
+            ngx.log(ngx.WARN, "session ended for user: " .. session.data.user.email)
+        else
+            ngx.log(ngx.WARN, "session ended")
       end
       return storage:destroy(session.encoder.encode(id))
     elseif storage.close then
@@ -86,10 +87,11 @@ function strategy.destroy(session)
 end
 
 function strategy.touch(session, close)
+    ngx.log(ngx.DEBUG, "session: " .. session.encoder.encode(session.id))
     if session.data and session.data.user then
-        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed for user: " .. session.data.user.email)
+        ngx.log(ngx.WARN, "session renewed for user: " .. session.data.user.email)
     else
-        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed")
+        ngx.log(ngx.WARN, "session renewed")
     end
 
     return default.modify(session, "save", close, key(session))

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -1,0 +1,70 @@
+local tonumber = tonumber
+local default = require "resty.session.strategies.default"
+local regenerate = require "resty.session.strategies.regenerate"
+
+local concat  = table.concat
+
+local defaults = {
+    concurrent_limit = tonumber(ngx.var.session_concurrent_limit) or 0
+}
+
+local strategy = {
+  start   = regenerate.start,
+  destroy = regenerate.destroy,
+  close   = regenerate.close,
+  open    = regenerate.open,
+  touch   = regenerate.touch
+}
+
+local function key(source)
+  if source.usebefore then
+    return concat{ source.id, source.usebefore }
+  end
+
+  return source.id
+end
+
+local function check_open_sessions(session)
+    -- check for current user session
+    if defaults.concurrent_limit > 0 then
+        ngx.log(ngx.DEBUG, "concurrent limit being checked...")
+        if session.data and session.data.user then
+            ngx.log(ngx.DEBUG, "user email: " .. session.encoder.encode(session.data.user.email))
+            -- take encoded email and slice to -2 to account for the padding flipping the last char exclude locks
+            -- TODO: could the -2 chars on the hash cause collisions? needs exploration
+            local encoded_name = session.encoder.encode(session.data.user.email)
+            local res = session.storage:scan(string.sub(encoded_name, 1, #encoded_name-2) .. "*[^.lock]")
+            if res and #res[2] >= defaults.concurrent_limit then
+                ngx.log(ngx.ERR, "session limit reached for user: " .. session.data.user.email)
+                return nil
+            end
+            ngx.log(ngx.DEBUG, "Limit not reached for user ID: " .. session.data.user.email .. " res: " .. type(res))
+            return true
+        end
+    end
+    ngx.log(ngx.DEBUG, "Session limits not configured")
+    return true
+end
+
+function strategy.save(session, close)
+    local storage = session.storage
+    ngx.log(ngx.DEBUG, "Strategy save process...")
+    if session.present then
+        if storage.ttl then
+            storage:ttl(session.encoder.encode(session.id), session.cookie.discard, true)
+        elseif storage.close then
+            storage:close(session.encoder.encode(session.id))
+        end
+
+        session.id = session:identifier()
+    end
+    if check_open_sessions(session) then
+        ngx.log(ngx.DEBUG, "Saving session")
+        return default.modify(session, "save", close, key(session))
+    else
+        ngx.log(ngx.STDERR, "Session limit reach session can not be saved")
+        return nil
+    end
+end
+
+return strategy

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -62,7 +62,7 @@ function strategy.save(session, close)
         return default.modify(session, "save", close, key(session))
     else
         ngx.log(ngx.ERROR, "Session limit reach session can not be saved")
-        return nil
+        return nil, "Session limit reached"
     end
 end
 

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -57,14 +57,13 @@ function strategy.save(session, close)
         elseif storage.close then
             storage:close(session.encoder.encode(session.id))
         end
-
         session.id = session:identifier()
     end
     if check_open_sessions(session) then
         ngx.log(ngx.DEBUG, "Saving session")
         return default.modify(session, "save", close, key(session))
     else
-        ngx.log(ngx.STDERR, "Session limit reach session can not be saved")
+        ngx.log(ngx.ERROR, "Session limit reach session can not be saved")
         return nil
     end
 end

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -61,7 +61,7 @@ function strategy.save(session, close)
         ngx.log(ngx.DEBUG, "Saving session")
         return default.modify(session, "save", close, key(session))
     else
-        ngx.log(ngx.ERROR, "Session limit reach session can not be saved")
+        ngx.log(ngx.ERR, "Session limit reach session can not be saved")
         return nil, "Session limit reached"
     end
 end

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -10,7 +10,6 @@ local defaults = {
 
 local strategy = {
   start   = regenerate.start,
-  destroy = regenerate.destroy,
   close   = regenerate.close,
   open    = regenerate.open,
   touch   = regenerate.touch
@@ -66,6 +65,25 @@ function strategy.save(session, close)
         ngx.log(ngx.ERROR, "Session limit reach session can not be saved")
         return nil
     end
+end
+
+function strategy.destroy(session)
+  local id = session.id
+  if id then
+    local storage = session.storage
+    if storage.destroy then
+      if session.data and session.data.user then
+        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(id) .. " ended for user: " .. session.data.user.email)
+      else
+        ngx.log(ngx.WARN, "session: " .. session.encoder.encode(id) .. " ended")
+      end
+      return storage:destroy(session.encoder.encode(id))
+    elseif storage.close then
+      ngx.log(ngx.WARN, "session close")
+      return storage:close(session.encoder.encode(id))
+    end
+  end
+  return true
 end
 
 return strategy

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -86,7 +86,7 @@ function strategy.destroy(session)
 end
 
 function strategy.touch(session, close)
-    ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed")
+    ngx.log(ngx.WARN, "session: " .. session.encoder.encode(session.id) .. " renewed for user: " .. session.data.user.email)
 
     return default.modify(session, "save", close, key(session))
 end

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -62,7 +62,7 @@ function strategy.save(session, close)
         return default.modify(session, "save", close, key(session))
     else
         ngx.log(ngx.ERR, "Session limit reach session can not be saved")
-        ngx.exit(ngx.HTTP_TOO_MANY_REQUESTS)
+        ngx.exit(430)
     end
 end
 

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -62,7 +62,7 @@ function strategy.save(session, close)
         return default.modify(session, "save", close, key(session))
     else
         ngx.log(ngx.ERR, "Session limit reach session can not be saved")
-        return nil, "Session limit reached"
+        ngx.exit(ngx.HTTP_TOO_MANY_REQUESTS)
     end
 end
 

--- a/lib/resty/session/strategies/sessionlimit.lua
+++ b/lib/resty/session/strategies/sessionlimit.lua
@@ -25,8 +25,10 @@ local function key(source)
 end
 
 local function check_open_sessions(session)
+    -- set configuration
+    local config = session.sessionlimit or defaults
     -- check for current user session
-    if defaults.concurrent_limit > 0 then
+    if config.concurrent_limit > 0 then
         ngx.log(ngx.DEBUG, "concurrent limit being checked...")
         if session.data and session.data.user then
             ngx.log(ngx.DEBUG, "user email: " .. session.encoder.encode(session.data.user.email))
@@ -34,7 +36,7 @@ local function check_open_sessions(session)
             -- TODO: could the -2 chars on the hash cause collisions? needs exploration
             local encoded_name = session.encoder.encode(session.data.user.email)
             local res = session.storage:scan(string.sub(encoded_name, 1, #encoded_name-2) .. "*[^.lock]")
-            if res and #res[2] >= defaults.concurrent_limit then
+            if res and #res[2] >= config.concurrent_limit then
                 ngx.log(ngx.ERR, "session limit reached for user: " .. session.data.user.email)
                 return nil
             end

--- a/lua-resty-session-dev-1.rockspec
+++ b/lua-resty-session-dev-1.rockspec
@@ -27,6 +27,7 @@ build = {
         ["resty.session.storage.memcached"]     = "lib/resty/session/storage/memcached.lua",
         ["resty.session.strategies.default"]    = "lib/resty/session/strategies/default.lua",
         ["resty.session.strategies.regenerate"] = "lib/resty/session/strategies/regenerate.lua",
+        ["resty.session.strategies.sessionlimit"] = "lib/resty/session/strategies/sessionlimit.lua",
         ["resty.session.hmac.sha1"]             = "lib/resty/session/hmac/sha1.lua",
         ["resty.session.ciphers.aes"]           = "lib/resty/session/ciphers/aes.lua",
         ["resty.session.ciphers.none"]          = "lib/resty/session/ciphers/none.lua",

--- a/lua-resty-session-dev-1.rockspec
+++ b/lua-resty-session-dev-1.rockspec
@@ -18,6 +18,7 @@ build = {
     modules = {
         ["resty.session"]                       = "lib/resty/session.lua",
         ["resty.session.identifiers.random"]    = "lib/resty/session/identifiers/random.lua",
+        ["resty.session.identifiers.uid"]       = "lib/resty/session/identifiers/uid.lua",
         ["resty.session.storage.shm"]           = "lib/resty/session/storage/shm.lua",
         ["resty.session.storage.dshm"]          = "lib/resty/session/storage/dshm.lua",
         ["resty.session.storage.redis"]         = "lib/resty/session/storage/redis.lua",


### PR DESCRIPTION
- Get the lua-resty-session latest version(3.10) of the 3.X series updates from mainstream as the 4.X is not backward compatible
- merge custom code introduced in the branch `add_session_identifier_ui` for assigning sessions UI identifiers