### PR TITLE
re-add sha256.lua hmac that was missed during the last 3.10 merge

### DIFF
--- a/lib/resty/session/hmac/sha256.lua
+++ b/lib/resty/session/hmac/sha256.lua
@@ -1,0 +1,8 @@
+local function hmac_sha256(secret, input)
+    local hmac = require("resty.hmac")
+    local digest = hmac:new(secret, hmac.ALGOS.SHA256)
+
+    return digest:final(input, false)
+end
+
+return hmac_sha256

--- a/lua-resty-session-dev-1.rockspec
+++ b/lua-resty-session-dev-1.rockspec
@@ -29,6 +29,7 @@ build = {
         ["resty.session.strategies.regenerate"] = "lib/resty/session/strategies/regenerate.lua",
         ["resty.session.strategies.sessionlimit"] = "lib/resty/session/strategies/sessionlimit.lua",
         ["resty.session.hmac.sha1"]             = "lib/resty/session/hmac/sha1.lua",
+        ["resty.session.hmac.sha256"]           = "lib/resty/session/hmac/sha256.lua",
         ["resty.session.ciphers.aes"]           = "lib/resty/session/ciphers/aes.lua",
         ["resty.session.ciphers.none"]          = "lib/resty/session/ciphers/none.lua",
         ["resty.session.compressors.none"]      = "lib/resty/session/compressors/none.lua",


### PR DESCRIPTION
- re-add sha256.lua hmac that was missed during the last 3.10 merge
- add sha256.lua  to the dev rockspec file